### PR TITLE
Faster sampling

### DIFF
--- a/abnet3/sampler.py
+++ b/abnet3/sampler.py
@@ -360,7 +360,7 @@ class SamplerCluster(SamplerBuilder):
                 p_spk_types['Stype_Sspk'][(spk, type_idx)] = \
                     spk_samp_func(W_spk_types[(spk, type_idx)])
             # Dtype, Sspk
-            for type_jdx in range(len(types)):
+            for type_jdx in range(type_idx + 1, len(types)):
                     min_idx = min(type_idx, type_jdx)
                     max_idx = max(type_idx, type_jdx)
                     if (spk, type_jdx) in W_spk_types:
@@ -369,7 +369,7 @@ class SamplerCluster(SamplerBuilder):
                             spk_samp_func(W_spk_types[(spk, type_jdx)])
             # Stype, Dspk
             for spk2 in speakers:
-                if (spk2, type_idx) in W_spk_types:
+                if spk != spk2 and (spk2, type_idx) in W_spk_types:
                     p_spk_types['Stype_Dspk'][(spk, spk2, type_idx)] = \
                         spk_samp_func(W_spk_types[(spk, type_idx)]) * \
                         spk_samp_func(W_spk_types[(spk2, type_idx)])
@@ -557,6 +557,8 @@ class SamplerClusterSiamese(SamplerCluster):
                     (spk1, type1), (spk2, type2) = key
                     type1 = int(type1)
                     type2 = int(type2)
+                    assert spk1 != spk2
+                    assert type1 != type2
                     tok1 = np.random.choice(token_dict[type1, spk1])
                     tok2 = np.random.choice(token_dict[type2, spk2])
                     sampled_tokens[config].append((tok1, tok2))
@@ -575,6 +577,7 @@ class SamplerClusterSiamese(SamplerCluster):
                 if config == 'Stype_Dspk':
                     for key in sample:
                         spk1, spk2, type_idx = key
+                        assert spk1 != spk2
                         type_idx = int(type_idx)
                         tok1 = np.random.choice(token_dict[type_idx, spk1])
                         tok2 = np.random.choice(token_dict[type_idx, spk2])
@@ -582,6 +585,7 @@ class SamplerClusterSiamese(SamplerCluster):
                 if config == 'Dtype_Sspk':
                     for key in sample:
                         spk, type_idx, type_jdx = key
+                        assert type_idx != type_jdx
                         type_idx = int(type_idx)
                         type_jdx = int(type_jdx)
                         tok1 = np.random.choice(token_dict[type_idx, spk])

--- a/abnet3/sampler.py
+++ b/abnet3/sampler.py
@@ -551,7 +551,7 @@ class SamplerClusterSiamese(SamplerCluster):
                 We sample two items and check they are different
                 """
                 keys = np.array(list(p_spk_types[config].keys()))
-                sample_idx = samplepairs_searchidx(cdf[config], sampled_ratio[config])
+                sample_idx = samplepairs_searchidx(cdf[config], sampled_ratio[config], keys=keys)
                 sample = keys[sample_idx]
                 for key in sample:
                     (spk1, type1), (spk2, type2) = key

--- a/abnet3/sampler.py
+++ b/abnet3/sampler.py
@@ -298,14 +298,11 @@ class SamplerCluster(SamplerBuilder):
                 W_types[tokens_type[tok]] += 1.0
             except Exception as e:
                 W_types[tokens_type[tok]] = 1.0
-        p_types = {"Stype": {}, "Dtype": {}}
+
+        p_types = dict()
 
         for type_idx in range(nb_types):
-            p_types["Stype"][type_idx] = type_samp_func(W_types[type_idx])
-            for type_jdx in range(type_idx+1, nb_types):
-                p_types["Dtype"][(type_idx, type_jdx)] = \
-                    type_samp_func(W_types[type_idx]) * \
-                    type_samp_func(W_types[type_jdx])
+            p_types[type_idx] = type_samp_func(W_types[type_idx])
         return p_types
 
     def sample_spk_p(self, std_descr, spk_sampling_mode='log'):
@@ -436,8 +433,7 @@ class SamplerCluster(SamplerBuilder):
         p_spk_types = self.sample_spk_p(std_descr,
                                         spk_sampling_mode=spk_sampling_mode)
 
-        for config in p_types.keys():
-            p_types[config] = normalize_distribution(p_types[config])
+        p_types = normalize_distribution(p_types)
 
         for config in p_spk_types.keys():
             p_spk_types[config] = normalize_distribution(p_spk_types[config])
@@ -451,23 +447,25 @@ class SamplerCluster(SamplerBuilder):
             i += 1
             if config == 'Stype_Sspk':
                 for el in p_spk_types[config].keys():
-                    p_spk_types[config][el] = p_types['Stype'][el[1]] * \
+                    p_spk_types[config][el] = \
+                        p_types[el[1]] * \
                         p_spk_types[config][el]
             if config == 'Stype_Dspk':
                 for el in p_spk_types[config].keys():
-                    p_spk_types[config][el] = p_types['Stype'][el[2]] * \
+                    p_spk_types[config][el] = \
+                        p_types[el[2]] * \
                         p_spk_types[config][el]
             if config == 'Dtype_Sspk':
                 for el in p_spk_types[config].keys():
-                    p_spk_types[config][el] = p_types['Dtype'][
-                                                               (el[1],
-                                                                el[2])] * \
+                    p_spk_types[config][el] = \
+                        p_types[el[1]] * \
+                        p_types[el[2]] * \
                         p_spk_types[config][el]
             if config == 'Dtype_Dspk':
                 for el in p_spk_types[config].keys():
-                    p_spk_types[config][el] = p_types['Dtype'][
-                                                               (el[2],
-                                                                el[3])] * \
+                    p_spk_types[config][el] = \
+                        p_types[el[2]] * \
+                        p_types[el[3]] * \
                         p_spk_types[config][el]
 
         for config in p_spk_types.keys():

--- a/abnet3/utils.py
+++ b/abnet3/utils.py
@@ -97,6 +97,27 @@ def sample_searchidx(cdf, num_samples):
     return idx
 
 
+def samplepairs_searchidx(cdf, num_samples):
+    """
+    Sample indexes based on cdf distribution
+    This function samples pairs of *different* elements (ie without 
+    replacement)
+    """
+    iterations = 0  # limit 5 iterations to avoid infinite loops
+    uniform_samples = np.random.random_sample((int(num_samples), 2))
+    idx = cdf.searchsorted(uniform_samples, side='right')
+    while True:
+        iterations += 1
+        if iterations > 5:
+            print("Warning : more than 5 iterations to sample different pairs")
+        indices_same_sample = np.where(idx[:, 0] == idx[:, 1])
+        num_samples_same = len(indices_same_sample[0])
+        if num_samples_same == 0:
+            break
+        new_samples = np.random.random_sample((int(num_samples_same), 2))
+        idx[indices_same_sample] = cdf.searchsorted(new_samples, side='right')
+    return idx
+
 def print_token(tok):
     """Pretty print token for batches
 


### PR DESCRIPTION
- Keep only one p_types instead of p_types["Stype"] and p_types["Dtype"] --> save memory and time

- For  `Dspk_Dtype`, keep only a dictionnary of proba p(speaker, type) instead of p(speaker1, type1, speaker2, type2). --> Sample two elements using it